### PR TITLE
Changing used metrics in zabbix due to Update

### DIFF
--- a/dbaas_zabbix/metrics.py
+++ b/dbaas_zabbix/metrics.py
@@ -1,8 +1,14 @@
 from collections import OrderedDict
 from dbaas_zabbix.errors import ZabbixApiKeyNotFoundError, ZabbixApiNoDataBetweenTimeError
 
-KEY_DISK_SIZE_DATA = 'hrStorageSizeInBytes[/data]'
-KEY_DISK_USED_DATA = 'hrStorageUsedInBytes[/data]'
+# Old Keys
+# KEY_DISK_SIZE_DATA = 'hrStorageSizeInBytes[/data]'
+# KEY_DISK_USED_DATA = 'hrStorageUsedInBytes[/data]'
+
+# New Keys
+# Values in Bytes
+KEY_DISK_SIZE_DATA = 'vfs.fs.size[/data,total]'
+KEY_DISK_USED_DATA = 'vfs.fs.size[/data,used]'
 
 
 class ZabbixMetrics(object):

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,8 +1,14 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-KEY_DISK_SIZE_DATA = 'hrStorageSizeInBytes[/data]'
-KEY_DISK_USED_DATA = 'hrStorageUsedInBytes[/data]'
+# Old Keys
+# KEY_DISK_SIZE_DATA = 'hrStorageSizeInBytes[/data]'
+# KEY_DISK_USED_DATA = 'hrStorageUsedInBytes[/data]'
+
+# New Keys
+# Values in Bytes
+KEY_DISK_SIZE_DATA = 'vfs.fs.size[/data,total]'
+KEY_DISK_USED_DATA = 'vfs.fs.size[/data,used]'
 
 
 class Item(object):


### PR DESCRIPTION
Changing used metrics in zabbix due to Update

Change 2 metrics:
KEY_DISK_SIZE_DATA = 'hrStorageSizeInBytes[/data]'
KEY_DISK_USED_DATA = 'hrStorageUsedInBytes[/data]'

To:
KEY_DISK_SIZE_DATA = 'vfs.fs.size[/data,total]'
KEY_DISK_USED_DATA = 'vfs.fs.size[/data,used]'